### PR TITLE
fix: improving locale handling in resource section components and update the header selection UI

### DIFF
--- a/frontend/src/components/footer/translator.tsx
+++ b/frontend/src/components/footer/translator.tsx
@@ -36,12 +36,12 @@ export const Translator = ({
           }}
           className={cn(
             "text-grey-50 w-full cursor-pointer appearance-none bg-transparent pr-6 focus:outline-none",
-            position === "header" ? "text-grey-400" : "",
+            position === "header" ? "text-grey-400 uppercase" : "",
           )}
         >
           {APP_CONTENT.LANGUAGES.filter((l) => l.supported).map((l) => (
             <option key={l.locale} value={l.locale}>
-              {l.language}
+              {position == "header" ? l.locale : l.language}
             </option>
           ))}
         </select>

--- a/frontend/src/components/header/navbar.tsx
+++ b/frontend/src/components/header/navbar.tsx
@@ -100,12 +100,12 @@ export const NavBar = ({
               })}
             </ul>
           </div>
-          <div className="flex items-center gap-x-4">
+          <div className="flex items-center gap-x-2">
             <Translator
               position="header"
               currentLocale={locale}
               currentPath={currentPath}
-              className="border-grey-50 hidden rounded-xl border shadow-xs md:flex"
+              className="border-grey-50 hidden rounded-xl border px-2 py-2.5 shadow-xs md:flex"
             />
             <div>
               {/* This is a hack to show different button sizes on mobile and desktop. Another alternative is to use javascript to get the screen width, but I decided to go with this for now. */}

--- a/frontend/src/components/home/astro-components/how-osm-works.astro
+++ b/frontend/src/components/home/astro-components/how-osm-works.astro
@@ -101,12 +101,11 @@ const home = getHomeContent(Astro.currentLocale);
     >
       <Button
         size="lg"
-        id="download-ebook-button"
+        id="learn-osm-button"
         class="gap-8 rounded-full font-normal"
-        href={home.HowOSMWorks.actions.downloadEbook.link}
-        icon_name="download"
+        href={home.HowOSMWorks.actions.learn.link}
       >
-        {home.HowOSMWorks.actions.downloadEbook.text}
+        {home.HowOSMWorks.actions.learn.text}
       </Button>
       <Button
         variant="secondary"

--- a/frontend/src/components/home/astro-components/osm-resources.astro
+++ b/frontend/src/components/home/astro-components/osm-resources.astro
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/react/button";
 import { getHomeContent } from "@/i18n/utils";
 
 const home = getHomeContent(Astro.currentLocale);
+const defaultLocale = Astro.currentLocale;
 ---
 
 <section class="bg-surface-30 py-12 md:px-12 lg:px-24">
@@ -19,7 +20,12 @@ const home = getHomeContent(Astro.currentLocale);
       </p>
     </div>
     <div class="min-h-[40rem] w-full">
-      <OSMResources client:load disablePagination={true} />
+      <OSMResources
+        locale={defaultLocale}
+        resourcesCategory={home.OSMResources.resourceCategories}
+        client:load
+        disablePagination={true}
+      />
     </div>
     <div class="mt-20 mb-12 flex justify-center">
       <Button

--- a/frontend/src/components/home/react-components/osm-resources.tsx
+++ b/frontend/src/components/home/react-components/osm-resources.tsx
@@ -1,4 +1,8 @@
-import { ResourceCategory, type ResourceItem } from "src/types/content";
+import {
+  getCategoryLabel,
+  ResourceCategory,
+  type ResourceItem,
+} from "src/types/content";
 import { APP_CONTENT } from "@/config/Content";
 import ResourceList from "@/components/resources/react-components/ResourceList";
 import { useEffect, useState } from "react";
@@ -6,48 +10,24 @@ import cn from "@/utils/cn";
 
 const OSMResources = ({
   disablePagination = false,
+  resourcesCategory,
+  locale = "en",
 }: {
   disablePagination?: boolean;
+  locale: string | undefined;
+  resourcesCategory: Array<{
+    id: number;
+    category: string;
+    description: string;
+  }>;
 }) => {
   const [isPaused, setIsPaused] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>(
-    ResourceCategory.EDITORS,
+    getCategoryLabel(ResourceCategory.EDITORS, locale),
   );
   const [resourcesList, setResourcesList] = useState<ResourceItem[]>(
     APP_CONTENT.RESOURCES_PAGE.resourcesList,
   );
-
-  const ResourcesCategory = [
-    {
-      id: 1,
-      category: ResourceCategory.EDITORS,
-      description: "Editors are too used to contribute to osm data",
-    },
-    {
-      id: 2,
-      category: ResourceCategory.DATA_EXTRACTION_AND_ANALYSIS,
-      description:
-        "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
-    },
-    {
-      id: 3,
-      category: ResourceCategory.MAP_VISUALIZATION_STACK,
-      description:
-        "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
-    },
-    {
-      id: 4,
-      category: ResourceCategory.LIBRARIES,
-      description:
-        "Code libraries in various programming languages to read, write, and manipulate OSM data.",
-    },
-    {
-      id: 5,
-      category: ResourceCategory.NAVIGATION,
-      description:
-        "Routing engines, on-device libraries, and mobile apps that turn OSM data into turn-by-turn navigation.",
-    },
-  ];
 
   const DESKTOP_BREAKPOINT = 1024;
 
@@ -69,12 +49,12 @@ const OSMResources = ({
     let nextCategory = category;
 
     if (autoAdvance) {
-      const currentIndex = ResourcesCategory.findIndex(
+      const currentIndex = resourcesCategory.findIndex(
         (cat) => cat.category === category,
       );
       const nextIndex =
-        currentIndex === ResourcesCategory.length - 1 ? 0 : currentIndex + 1;
-      nextCategory = ResourcesCategory[nextIndex].category;
+        currentIndex === resourcesCategory.length - 1 ? 0 : currentIndex + 1;
+      nextCategory = resourcesCategory[nextIndex].category;
     }
 
     setActiveCategory(nextCategory);
@@ -102,7 +82,7 @@ const OSMResources = ({
   return (
     <div className="flex md:gap-4">
       <ul className="flex flex-col gap-8 lg:max-w-[22.56rem]">
-        {ResourcesCategory.map((category) => (
+        {resourcesCategory.map((category) => (
           <li
             key={category.id}
             className={cn(

--- a/frontend/src/content/events/en/mapkaton-2026.mdx
+++ b/frontend/src/content/events/en/mapkaton-2026.mdx
@@ -44,14 +44,14 @@ AI is now part of working with open data, for querying it, summarizing it, and b
     {
       title: "Async Build Phase",
       description:
-        "Work on your own schedule. Prepare your data, build your analysis, or develop your tool. Finalize everything before August 7th, 2026.",
+        "Work on your own schedule. Prepare your data, build your analysis, or develop your tool. Finalize everything before August 14th, 2026.",
       startDate: "15-07-2026",
-      endDate: "7-08-2026",
+      endDate: "14-08-2026",
     },
     {
       title: "Judging",
       description: "Results are reviewed and scored by the panel.",
-      startDate: "7-08-2026",
+      startDate: "14-08-2026",
       endDate: "21-08-2026",
     },
     {

--- a/frontend/src/content/events/fr/mapkaton-2026.mdx
+++ b/frontend/src/content/events/fr/mapkaton-2026.mdx
@@ -46,14 +46,14 @@ L'IA fait désormais partie du travail avec les données ouvertes, pour les inte
     {
       title: "Phase de réalisation en asynchrone",
       description:
-        "Travaillez à votre rythme. Préparez vos données, construisez votre analyse ou développez votre outil. Terminez le tout avant le 7 août 2026.",
+        "Travaillez à votre rythme. Préparez vos données, construisez votre analyse ou développez votre outil. Terminez le tout avant le 14 août 2026.",
       startDate: "15-07-2026",
-      endDate: "7-08-2026",
+      endDate: "14-08-2026",
     },
     {
       title: "Évaluation",
       description: "Les résultats sont examinés et notés par le jury.",
-      startDate: "7-08-2026",
+      startDate: "14-08-2026",
       endDate: "21-08-2026",
     },
     {

--- a/frontend/src/i18n/content/home.ts
+++ b/frontend/src/i18n/content/home.ts
@@ -1,4 +1,8 @@
-import type { HomePageContent } from "src/types/content";
+import {
+  getCategoryLabel,
+  ResourceCategory,
+  type HomePageContent,
+} from "src/types/content";
 import type { Locale } from "@/i18n/ui";
 import OsmStep1 from "@/assets/images/osm_step_1.jpg";
 import OsmStep2 from "@/assets/images/osm_step_2.jpg";
@@ -38,6 +42,43 @@ export const homeContent: Record<Locale, HomePageContent> = {
         title: "Explore All Resources",
         link: "/en/resources",
       },
+      resourceCategories: [
+        {
+          id: 1,
+          category: getCategoryLabel(ResourceCategory.EDITORS, "en"),
+          description: "Editors are too used to contribute to osm data",
+        },
+        {
+          id: 2,
+          category: getCategoryLabel(
+            ResourceCategory.DATA_EXTRACTION_AND_ANALYSIS,
+            "en",
+          ),
+          description:
+            "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
+        },
+        {
+          id: 3,
+          category: getCategoryLabel(
+            ResourceCategory.MAP_VISUALIZATION_STACK,
+            "en",
+          ),
+          description:
+            "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
+        },
+        {
+          id: 4,
+          category: getCategoryLabel(ResourceCategory.LIBRARIES, "en"),
+          description:
+            "Code libraries in various programming languages to read, write, and manipulate OSM data.",
+        },
+        {
+          id: 5,
+          category: getCategoryLabel(ResourceCategory.NAVIGATION, "en"),
+          description:
+            "Routing engines, on-device libraries, and mobile apps that turn OSM data into turn-by-turn navigation.",
+        },
+      ],
     },
     HowOSMWorks: {
       tagline: "How OSM Works",
@@ -64,8 +105,8 @@ export const homeContent: Record<Locale, HomePageContent> = {
       ],
       actions: {
         title: "Ready to start contributing ?",
-        downloadEbook: {
-          text: "Download eBook",
+        learn: {
+          text: "Learn OSM",
           link: "https://learnosm.org/en/beginner/",
         },
         watchVideo: {
@@ -132,6 +173,43 @@ export const homeContent: Record<Locale, HomePageContent> = {
         title: "Explorer toutes les ressources",
         link: "/fr/resources",
       },
+      resourceCategories: [
+        {
+          id: 1,
+          category: getCategoryLabel(ResourceCategory.EDITORS, "fr"),
+          description: "Editors are too used to contribute to osm data",
+        },
+        {
+          id: 2,
+          category: getCategoryLabel(
+            ResourceCategory.DATA_EXTRACTION_AND_ANALYSIS,
+            "fr",
+          ),
+          description:
+            "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
+        },
+        {
+          id: 3,
+          category: getCategoryLabel(
+            ResourceCategory.MAP_VISUALIZATION_STACK,
+            "fr",
+          ),
+          description:
+            "Utilities and libraries to query, extract, and analyze raw OpenStreetMap data at scale.",
+        },
+        {
+          id: 4,
+          category: getCategoryLabel(ResourceCategory.LIBRARIES, "fr"),
+          description:
+            "Code libraries in various programming languages to read, write, and manipulate OSM data.",
+        },
+        {
+          id: 5,
+          category: getCategoryLabel(ResourceCategory.NAVIGATION, "fr"),
+          description:
+            "Routing engines, on-device libraries, and mobile apps that turn OSM data into turn-by-turn navigation.",
+        },
+      ],
     },
     HowOSMWorks: {
       tagline: "Comment fonctionne OSM",
@@ -158,8 +236,8 @@ export const homeContent: Record<Locale, HomePageContent> = {
       ],
       actions: {
         title: "Prêt à commencer à contribuer ?",
-        downloadEbook: {
-          text: "Télécharger l'eBook",
+        learn: {
+          text: "Apprenez OSM",
           link: "https://learnosm.org/fr/beginner/",
         },
         watchVideo: {

--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -63,6 +63,11 @@ export type HomePageContent = {
       title: string;
       link: string;
     };
+    resourceCategories: Array<{
+      id: number;
+      category: string;
+      description: string;
+    }>;
   };
   OrgsUsingOSM: {
     title: string;
@@ -83,7 +88,7 @@ export type HomePageContent = {
     }>;
     actions: {
       title: string;
-      downloadEbook: {
+      learn: {
         text: string;
         link: string;
       };
@@ -134,6 +139,43 @@ export enum ResourceCategory {
   MOBILE = "Mobile",
 }
 
+const resourceCategoryLabels: Record<
+  string,
+  Record<ResourceCategory, string>
+> = {
+  en: {
+    [ResourceCategory.ALL]: "All",
+    [ResourceCategory.EDITORS]: "Editors",
+    [ResourceCategory.DATA_EXTRACTION_AND_ANALYSIS]:
+      "Data Extraction and Analysis",
+    [ResourceCategory.MAP_VISUALIZATION_STACK]: "Map Visualization",
+    [ResourceCategory.DATA_ANALYTICS]: "Data Analytics",
+    [ResourceCategory.USER_INTERACTION]: "User Interaction",
+    [ResourceCategory.LIBRARIES]: "Libraries",
+    [ResourceCategory.NAVIGATION]: "Navigation",
+    [ResourceCategory.MOBILE]: "Mobile",
+  },
+  fr: {
+    [ResourceCategory.ALL]: "Tous",
+    [ResourceCategory.EDITORS]: "Éditeurs",
+    [ResourceCategory.DATA_EXTRACTION_AND_ANALYSIS]:
+      "Extraction et analyse de données",
+    [ResourceCategory.MAP_VISUALIZATION_STACK]: "Visualisation cartographique",
+    [ResourceCategory.DATA_ANALYTICS]: "Analyse de données",
+    [ResourceCategory.USER_INTERACTION]: "Interaction utilisateur",
+    [ResourceCategory.LIBRARIES]: "Bibliothèques",
+    [ResourceCategory.NAVIGATION]: "Navigation",
+    [ResourceCategory.MOBILE]: "Mobile",
+  },
+};
+
+// usage
+export const getCategoryLabel = (
+  category: ResourceCategory,
+  lang: string = "en",
+): string => {
+  return resourceCategoryLabels[lang]?.[category] ?? category;
+};
 export type ResourceItem = {
   id: number;
   title: string;


### PR DESCRIPTION
**Description**

This PR improves how locale is handled for resource category content on the home page, ensuring content displays correctly based on the active locale, and extends Mapkathon submission date

**What the PR contains**:

- Mapkathon submission date was updated to 14th August, 2026
- Fixed home page resources category translation
- Updated translation UI for only the header component 